### PR TITLE
timber: desktop: fix input focus when destroying client

### DIFF
--- a/timber.c
+++ b/timber.c
@@ -547,7 +547,8 @@ static int tmbr_desktop_remove_client(tmbr_desktop_t *desktop, tmbr_client_t *cl
 		tmbr_tree_t *sibling;
 		if (tmbr_tree_find_sibling(&sibling, client->tree, TMBR_SELECT_NEAREST) < 0)
 			sibling = NULL;
-		tmbr_desktop_focus_client(desktop, sibling ? sibling->client : NULL, 1);
+		tmbr_desktop_focus_client(desktop, sibling ? sibling->client : NULL,
+					  desktop->screen == state.screen && desktop->screen->focus == desktop);
 	}
 
 	if (tmbr_tree_remove(&desktop->clients, client->tree) < 0)


### PR DESCRIPTION
When destroying clients on a desktop whose screen is currently not
focussed, then we try to adjust the input focus anyway, ending up with
the input focus residing on that other screen. Fix this by only setting
the input focus in case where a client is getting destroyed on the
currently focussed screen and desktop.