### PR TITLE
timber: tree: set new node's split according to their ratio

### DIFF
--- a/timber.c
+++ b/timber.c
@@ -190,6 +190,8 @@ static int tmbr_tree_insert(tmbr_tree_t **tree, tmbr_client_t *client)
 	t->client = NULL;
 	t->left = l;
 	t->right = r;
+	t->ratio = 50;
+	t->split = (l->client->w < l->client->h) ? TMBR_SPLIT_HORIZONTAL : TMBR_SPLIT_VERTICAL;
 
 	return 0;
 }


### PR DESCRIPTION
When inserting a new client into the tree, we currently always split the
client's parent tree vertically. While simple and deterministic, we can
try to make better use of the available space. Instead of always
splitting the same, we can split according to the aspect ratio of the
node's available space:

- if the node is wider than it is high, then we split vertically
- if the node is higher than it is wide, then we split horizontally