### PR TITLE
timber: merge tree_{swap,rotate} commands

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -19,7 +19,6 @@ static const tmbr_command_t cmds[] = {
 	{ "desktop_new",       tmbr_cmd_desktop_new,       0                         },
 	{ "screen_focus",      tmbr_cmd_screen_focus,      TMBR_ARG_SEL              },
 	{ "tree_rotate",       tmbr_cmd_tree_rotate,       0                         },
-	{ "tree_swap",         tmbr_cmd_tree_swap,         0                         }
 };
 
 /* vim: set tabstop=8 noexpandtab : */

--- a/timber.c
+++ b/timber.c
@@ -123,7 +123,6 @@ static void tmbr_cmd_desktop_kill(const tmbr_command_args_t *args);
 static void tmbr_cmd_desktop_focus(const tmbr_command_args_t *args);
 static void tmbr_cmd_screen_focus(const tmbr_command_args_t *args);
 static void tmbr_cmd_tree_rotate(const tmbr_command_args_t *args);
-static void tmbr_cmd_tree_swap(const tmbr_command_args_t *args);
 
 #include "config.h"
 
@@ -1045,27 +1044,19 @@ static void tmbr_cmd_screen_focus(const tmbr_command_args_t *args)
 static void tmbr_cmd_tree_rotate(TMBR_UNUSED const tmbr_command_args_t *args)
 {
 	tmbr_client_t *focus;
+	tmbr_tree_t *p;
 
 	if (tmbr_client_find_by_focus(&focus) < 0 ||
-	    !focus->tree->parent)
+	    (p = focus->tree->parent) == NULL)
 		return;
 
-	focus->tree->parent->split = !focus->tree->parent->split;
+	if (p->split == TMBR_SPLIT_HORIZONTAL) {
+		tmbr_tree_t *l = p->left;
+		p->left = p->right;
+		p->right = l;
+	}
+	p->split ^= 1;
 
-	tmbr_desktop_layout(focus->desktop);
-}
-
-static void tmbr_cmd_tree_swap(TMBR_UNUSED const tmbr_command_args_t *args)
-{
-	tmbr_client_t *focus;
-	tmbr_tree_t *l;
-
-	if (tmbr_client_find_by_focus(&focus) < 0 || !focus->tree->parent)
-		return;
-
-	l = focus->tree->parent->left;
-	focus->tree->parent->left = focus->tree->parent->right;
-	focus->tree->parent->right = l;
 	tmbr_desktop_layout(focus->desktop);
 }
 


### PR DESCRIPTION
Instead of having two commands "tree_swap" and "tree_rotate", we can
conceptionally merge the former one into the latter one by extending
what "tree_rotate" does. Instead of only rotating once, it will rotate
the currently focussed completely around its own axis. Thus, executing
"tree_rotate" twice is exactly the same as executing "tree_swap" once.

Do so and remove "tree_swap" in favor of "tree_rotate".