### PR TITLE
timber: cmd: fix misnamed "client_to_monitor" command

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -13,7 +13,7 @@ static const tmbr_command_t cmds[] = {
 	{ "client_resize",     tmbr_cmd_client_resize,     TMBR_ARG_DIR|TMBR_ARG_INT },
 	{ "client_swap",       tmbr_cmd_client_swap,       TMBR_ARG_SEL              },
 	{ "client_to_desktop", tmbr_cmd_client_to_desktop, TMBR_ARG_SEL              },
-	{ "client_to_monitor", tmbr_cmd_client_to_monitor, TMBR_ARG_SEL              },
+	{ "client_to_screen",  tmbr_cmd_client_to_screen,  TMBR_ARG_SEL              },
 	{ "desktop_focus",     tmbr_cmd_desktop_focus,     TMBR_ARG_SEL              },
 	{ "desktop_kill",      tmbr_cmd_desktop_kill,      0                         },
 	{ "desktop_new",       tmbr_cmd_desktop_new,       0                         },

--- a/timber.c
+++ b/timber.c
@@ -116,7 +116,7 @@ static void tmbr_cmd_client_focus(const tmbr_command_args_t *args);
 static void tmbr_cmd_client_fullscreen(const tmbr_command_args_t *args);
 static void tmbr_cmd_client_to_desktop(const tmbr_command_args_t *args);
 static void tmbr_cmd_client_resize(const tmbr_command_args_t *args);
-static void tmbr_cmd_client_to_monitor(const tmbr_command_args_t *args);
+static void tmbr_cmd_client_to_screen(const tmbr_command_args_t *args);
 static void tmbr_cmd_client_swap(const tmbr_command_args_t *args);
 static void tmbr_cmd_desktop_new(const tmbr_command_args_t *args);
 static void tmbr_cmd_desktop_kill(const tmbr_command_args_t *args);
@@ -973,7 +973,7 @@ static void tmbr_cmd_client_resize(const tmbr_command_args_t *args)
 	tmbr_desktop_layout(client->desktop);
 }
 
-static void tmbr_cmd_client_to_monitor(const tmbr_command_args_t *args)
+static void tmbr_cmd_client_to_screen(const tmbr_command_args_t *args)
 {
 	tmbr_screen_t *screen;
 	tmbr_client_t *client;


### PR DESCRIPTION
The "client_to_monitor" command is misnamed, as it accidentally refers
to "monitor" instead of "screen". Rename it to "client_to_screen" to fix
this.