### PR TITLE
Fix input focus when desktop is empty

### DIFF
--- a/timber.c
+++ b/timber.c
@@ -781,13 +781,6 @@ static int tmbr_client_find_by_window(tmbr_client_t **out, xcb_window_t window)
 	return -1;
 }
 
-static void tmbr_handle_focus_in(xcb_focus_in_event_t *ev)
-{
-	tmbr_client_t *client;
-	if (tmbr_client_find_by_focus(&client) == 0 && client->window != ev->event)
-		tmbr_desktop_focus(client->desktop, client, 1);
-}
-
 static void tmbr_handle_enter_notify(xcb_enter_notify_event_t *ev)
 {
 	tmbr_client_t *client;
@@ -859,9 +852,7 @@ static void tmbr_handle_screen_change_notify(void)
 static void tmbr_handle_event(xcb_generic_event_t *ev)
 {
 	uint8_t type = XCB_EVENT_RESPONSE_TYPE(ev);
-	if (type == XCB_FOCUS_IN)
-		tmbr_handle_focus_in((xcb_focus_in_event_t *) ev);
-	else if (type == XCB_ENTER_NOTIFY)
+	if (type == XCB_ENTER_NOTIFY)
 		tmbr_handle_enter_notify((xcb_enter_notify_event_t *) ev);
 	else if (type == XCB_MAP_REQUEST)
 		tmbr_handle_map_request((xcb_map_request_event_t *) ev);


### PR DESCRIPTION
When there's multiple desktops and one of both desktops is empty, then
the input focus will be set incorrectly when selecting the empty
desktop. Instead of not having any input focus at all, the input focus
will be set to the window that's located below the current pointer
position.

X11 does not allow for having no input focus at all for non-reparenting
window managers. To work around this, we create a dummy window that we
will set the input focus to instead of setting it to the root window. To
avoid any window manager messing with this dummy window, we set the
override redirect window attribute on it.

This fixes the described input focus issues.