### PR TITLE
timber: map clients after resizing

### DIFF
--- a/timber.c
+++ b/timber.c
@@ -803,11 +803,13 @@ static void tmbr_handle_map_request(xcb_map_request_event_t *ev)
 	if (override || tmbr_client_find_by_window(&client, ev->window) == 0)
 		return;
 
+	if (tmbr_client_new(&client, ev->window) < 0)
+	    die("Unable to create new client");
+
 	xcb_map_window(state.conn, ev->window);
 
-	if (tmbr_client_new(&client, ev->window) < 0 ||
-	    tmbr_desktop_add_client(state.screen->focus, client, 1) < 0)
-		die("Unable to manage client");
+	if (tmbr_desktop_add_client(state.screen->focus, client, 1) < 0)
+		die("Unable to add new client to desktop");
 }
 
 static void tmbr_handle_destroy_notify(xcb_destroy_notify_event_t *ev)


### PR DESCRIPTION
When mapping clients immediately before resizing them, some
clients will not properly update their contents to match the
resized aspects, but the old one. Fix this by mapping windows
after resizing, but before trying to focus it in order to avoid
BadMatch errors.