### PR TITLE
README: fix path to control pipe

### DIFF
--- a/README
+++ b/README
@@ -48,7 +48,7 @@ the DISPLAY variable:
 When timber is running, you can execute commands by writing them
 into its control named pipe:
 
-    $ echo -n "client_focus next >/tmp/timber.s"
+    $ echo -n "client_focus next >/run/timber/ctrl.s"
 
 Usually, you would configure a hotkey manager like sxhkd to bind
 these commands to hotkeys.


### PR DESCRIPTION
The control pipe has been moved from /tmp to /run/timber in commit
7cbee80 (timber: ctrl: move named pipe to reside in /run/timber,
2019-03-15), but the README file has not been adjusted. Fix this.