### PR TITLE
timber: reorder setup to avoid overwriting control socket

### DIFF
--- a/timber.c
+++ b/timber.c
@@ -1185,6 +1185,13 @@ static int tmbr_setup(void)
 {
 	char *dir;
 
+	if ((state.conn = xcb_connect(NULL, NULL)) == NULL ||
+	    xcb_connection_has_error(state.conn) != 0)
+		die("Unable to connect to X server");
+
+	if (tmbr_setup_x11(state.conn) < 0)
+		die("Unable to setup X server");
+
 	if ((state.ctrl_path = getenv("TMBR_CTRL_PATH")) == NULL)
 		state.ctrl_path = TMBR_CTRL_PATH;
 
@@ -1198,13 +1205,6 @@ static int tmbr_setup(void)
 
 	if ((state.fifofd = open(state.ctrl_path, O_RDWR|O_NONBLOCK)) < 0)
 		die("Unable to open fifo");
-
-	if ((state.conn = xcb_connect(NULL, NULL)) == NULL ||
-	    xcb_connection_has_error(state.conn) != 0)
-		die("Unable to connect to X server");
-
-	if (tmbr_setup_x11(state.conn) < 0)
-		die("Unable to setup X server");
 
 	signal(SIGINT, tmbr_cleanup);
 	signal(SIGHUP, tmbr_cleanup);


### PR DESCRIPTION
Right now, we first set up the control socket and only afterwards
try to set up the X11 connection. If we fail to set up X11,
though, for example because another instance of timebr is already
running, then we have already overwritten the control socket and
will only fail afterwards. This renders the old instance of
timber uncontrollable.

Fix this by reversing the order: try to connect to X11 first and
then set up our control structures.