### PR TITLE
timber: split commands into main and subcommand

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -44,7 +44,7 @@ static int tmbr_dispatch_command(tmbr_command_t cmd, const tmbr_command_args_t *
 	if (commands[cmd].args & TMBR_ARG_INT)
 		snprintf(params[2], sizeof(params[2]), " %i", args->i);
 
-	dprintf(fd, "%s%s%s%s\n", commands[cmd].command, params[0], params[1], params[2]);
+	dprintf(fd, "%s %s%s%s%s\n", commands[cmd].cmd, commands[cmd].subcmd, params[0], params[1], params[2]);
 
 	return 0;
 }

--- a/src/common.c
+++ b/src/common.c
@@ -23,18 +23,18 @@
 #include "common.h"
 
 const tmbr_commands_t commands[] = {
-	{ "client_focus",      TMBR_ARG_SEL              },
-	{ "client_fullscreen", 0                         },
-	{ "client_kill",       0                         },
-	{ "client_resize",     TMBR_ARG_DIR|TMBR_ARG_INT },
-	{ "client_swap",       TMBR_ARG_SEL              },
-	{ "client_to_desktop", TMBR_ARG_SEL              },
-	{ "client_to_screen",  TMBR_ARG_SEL              },
-	{ "desktop_focus",     TMBR_ARG_SEL              },
-	{ "desktop_kill",      0                         },
-	{ "desktop_new",       0                         },
-	{ "screen_focus",      TMBR_ARG_SEL              },
-	{ "tree_rotate",       0                         }
+	{ "client", "focus",      TMBR_ARG_SEL              },
+	{ "client", "fullscreen", 0                         },
+	{ "client", "kill",       0                         },
+	{ "client", "resize",     TMBR_ARG_DIR|TMBR_ARG_INT },
+	{ "client", "swap",       TMBR_ARG_SEL              },
+	{ "client", "to_desktop", TMBR_ARG_SEL              },
+	{ "client", "to_screen",  TMBR_ARG_SEL              },
+	{ "desktop", "focus",     TMBR_ARG_SEL              },
+	{ "desktop", "kill",      0                         },
+	{ "desktop", "new",       0                         },
+	{ "screen", "focus",      TMBR_ARG_SEL              },
+	{ "tree", "rotate",       0                         }
 };
 
 const char *directions[] = { "north", "south", "east", "west" };
@@ -58,7 +58,7 @@ void __attribute__((noreturn)) usage(const char *executable)
 	printf("USAGE: %s\n", executable);
 
 	for (i = 0; i < ARRAY_SIZE(commands); i++)
-		printf("   or: %s %s%s%s%s\n", executable, commands[i].command,
+		printf("   or: %s %s %s%s%s%s\n", executable, commands[i].cmd, commands[i].subcmd,
 			commands[i].args & TMBR_ARG_SEL ? " (next|prev)" : "",
 			commands[i].args & TMBR_ARG_DIR ? " (north|south|east|west)" : "",
 			commands[i].args & TMBR_ARG_INT ? " <NUMBER>" : "");
@@ -70,22 +70,22 @@ int tmbr_command_parse(tmbr_command_t *cmd, tmbr_command_args_t *args, int argc,
 {
 	ssize_t c, i;
 
-	if (!argc)
+	if (argc < 2)
 		return -1;
 
-	ARRAY_FIND(commands, c, strcmp(commands[c].command, argv[0]));
+	ARRAY_FIND(commands, c, !strcmp(commands[c].cmd, argv[0]) && !strcmp(commands[c].subcmd, argv[1]));
 	if (c < 0)
 		return -1;
 	*cmd = (tmbr_command_t) c;
 
-	argc--;
-	argv++;
+	argc -= 2;
+	argv += 2;
 
 	if (commands[c].args & TMBR_ARG_SEL) {
 		if (!argc)
 			return -1;
 
-		ARRAY_FIND(commands, i, strcmp(argv[0], selections[i]));
+		ARRAY_FIND(commands, i, !strcmp(argv[0], selections[i]));
 		if (i < 0)
 			return -1;
 		args->sel = (tmbr_select_t) i;
@@ -97,7 +97,7 @@ int tmbr_command_parse(tmbr_command_t *cmd, tmbr_command_args_t *args, int argc,
 		if (!argc)
 			return -1;
 
-		ARRAY_FIND(commands, i, strcmp(argv[0], directions[i]));
+		ARRAY_FIND(commands, i, !strcmp(argv[0], directions[i]));
 		if (i < 0)
 			return -1;
 		args->dir = (tmbr_dir_t) i;

--- a/src/common.h
+++ b/src/common.h
@@ -20,7 +20,7 @@
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(*a))
 #define ARRAY_FIND(array, i, cmp) \
 	for (i = 0; i < (ssize_t)ARRAY_SIZE(array); i++) \
-		if (!cmp) \
+		if (cmp) \
 			break; \
 	if (i == ARRAY_SIZE(array)) \
 		i = -1;
@@ -64,7 +64,8 @@ typedef struct {
 } tmbr_command_args_t;
 
 typedef struct {
-	const char *command;
+	const char *cmd;
+	const char *subcmd;
 	int args;
 } tmbr_commands_t;
 


### PR DESCRIPTION
It's awkward and uncommon to use commands like "timber
client_select next". Switch this over to use command and
subcommand instead, so that the above becomes "timber client
select next".