### PR TITLE
Unix sockets for control pipes

### DIFF
--- a/src/wm.c
+++ b/src/wm.c
@@ -97,7 +97,7 @@ static struct {
 		xcb_atom_t net_wm_state;
 		xcb_atom_t net_wm_state_fullscreen;
 	} atoms;
-	int fifofd;
+	int ctrlfd;
 	uint8_t ignored_events;
 } state = { NULL, NULL, NULL, 0, 0, NULL, NULL, { 0 }, -1, 0 };
 
@@ -1038,8 +1038,8 @@ static void tmbr_handle_command(int fd)
 
 static void tmbr_cleanup(TMBR_UNUSED int signal)
 {
-	if (state.fifofd >= 0)
-		close(state.fifofd);
+	if (state.ctrlfd >= 0)
+		close(state.ctrlfd);
 	unlink(state.ctrl_path);
 
 	tmbr_screens_free(state.screens);
@@ -1123,7 +1123,7 @@ static int tmbr_setup_socket(void)
 	    (mkfifo(state.ctrl_path, 0600) < 0 && errno != EEXIST))
 		die("Unable to create fifo");
 
-	if ((state.fifofd = open(state.ctrl_path, O_RDWR|O_NONBLOCK)) < 0)
+	if ((state.ctrlfd = open(state.ctrl_path, O_RDWR|O_NONBLOCK)) < 0)
 		die("Unable to open fifo");
 
 	free(dir);
@@ -1154,7 +1154,7 @@ int tmbr_wm(void)
 
 	fds[0].fd = xcb_get_file_descriptor(state.conn);
 	fds[0].events = POLLIN;
-	fds[1].fd = state.fifofd;
+	fds[1].fd = state.ctrlfd;
 	fds[1].events = POLLIN;
 
 	while (xcb_flush(state.conn) > 0) {

--- a/src/wm.c
+++ b/src/wm.c
@@ -1108,12 +1108,9 @@ static int tmbr_setup_x11(void)
 	return 0;
 }
 
-static int tmbr_setup(void)
+static int tmbr_setup_socket(void)
 {
 	char *dir;
-
-	if (tmbr_setup_x11(state.conn) < 0)
-		die("Unable to setup X server");
 
 	if ((state.ctrl_path = getenv("TMBR_CTRL_PATH")) == NULL)
 		state.ctrl_path = TMBR_CTRL_PATH;
@@ -1129,12 +1126,22 @@ static int tmbr_setup(void)
 	if ((state.fifofd = open(state.ctrl_path, O_RDWR|O_NONBLOCK)) < 0)
 		die("Unable to open fifo");
 
+	free(dir);
+	return 0;
+}
+
+static int tmbr_setup(void)
+{
+	if (tmbr_setup_x11(state.conn) < 0)
+		die("Unable to setup X server");
+	if (tmbr_setup_socket() < 0)
+		die("Unable to setup control socket");
+
 	signal(SIGINT, tmbr_cleanup);
 	signal(SIGHUP, tmbr_cleanup);
 	signal(SIGTERM, tmbr_cleanup);
 	signal(SIGCHLD, tmbr_cleanup);
 
-	free(dir);
 	return 0;
 }
 

--- a/src/wm.c
+++ b/src/wm.c
@@ -1061,11 +1061,16 @@ static int tmbr_setup_atom(xcb_atom_t *out, char *name)
 	return 0;
 }
 
-static int tmbr_setup_x11(xcb_connection_t *conn)
+static int tmbr_setup_x11(void)
 {
 	uint32_t mask = XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY;
 	uint32_t override_redirect = 1;
+	xcb_connection_t *conn;
 	xcb_screen_t *screen;
+
+	if ((state.conn = conn = xcb_connect(NULL, NULL)) == NULL ||
+	    xcb_connection_has_error(conn) != 0)
+		die("Unable to connect to X server");
 
 	if ((screen = xcb_setup_roots_iterator(xcb_get_setup(conn)).data) == NULL)
 		die("Unable to get root screen");
@@ -1106,10 +1111,6 @@ static int tmbr_setup_x11(xcb_connection_t *conn)
 static int tmbr_setup(void)
 {
 	char *dir;
-
-	if ((state.conn = xcb_connect(NULL, NULL)) == NULL ||
-	    xcb_connection_has_error(state.conn) != 0)
-		die("Unable to connect to X server");
 
 	if (tmbr_setup_x11(state.conn) < 0)
 		die("Unable to setup X server");


### PR DESCRIPTION
Since timber's inception, we've been using a FIFO control pipe to
receive commands. The downside of using FIFOs is that they are
unidirectional only and thus do not allow us to return any data
to the client. There are some usecases though which would require
us to do exactly that, for example if we want to be able to
return events to registered clients or success/failure messages.

Switch over client and window manager to use AF_UNIX sockets in
SOCK_STREAM mode. We do not yet make any use of the new
possibilities, though, but will do that at a later point.
