### PR TITLE
wm: fix toggling fullscreen for unfocussed clients

### DIFF
--- a/src/wm.c
+++ b/src/wm.c
@@ -456,6 +456,7 @@ static int tmbr_desktop_unfocus(tmbr_desktop_t *desktop)
 
 static int tmbr_desktop_set_fullscreen(tmbr_desktop_t *desktop, tmbr_client_t *client, uint8_t fs)
 {
+	tmbr_desktop_focus(desktop, client, 1);
 	desktop->fullscreen = fs;
 	tmbr_desktop_layout(desktop);
 	return tmbr_client_set_fullscreen(client, fs);


### PR DESCRIPTION
When a client requests to go into fullscreen mode, then we adjust the
`fs` bit of its desktop and re-layout it. If the message is sent by an
unfocussed client, though, then we will notify it of being set to
fullscreen, but will draw the currently focussed client at full size
instead of the correct one.

Fix this by adjusting the desktop's focussed client before re-layouting
windows.