### PR TITLE
wm: layout windows before mapping them

### DIFF
--- a/src/wm.c
+++ b/src/wm.c
@@ -751,7 +751,8 @@ static void tmbr_handle_map_request(xcb_map_request_event_t *ev)
 		return;
 
 	if (tmbr_client_new(&client, ev->window) < 0 ||
-	    tmbr_desktop_add_client(state.screen->focus, client) < 0)
+	    tmbr_desktop_add_client(state.screen->focus, client) < 0 ||
+	    tmbr_desktop_layout(state.screen->focus) < 0)
 		die("Unable to manage client");
 
 	xcb_map_window(state.conn, ev->window);


### PR DESCRIPTION
When receiving a map request, then we will add the client to the current
desktop, map it and last focus and layout it. Doing the layouting after
mapping the window proves to be nasty, though:

- Some X11 clients have racy window handling. When receiving a mapping
  notification directly followed by a size reconfiguration, they may
  ignore the reconfiguration and use continue to use their previous
  default width and height.

- One may see the window flashing up for a brief moment at its default
  location.

Fix the issue by calling `tmbr_desktop_layout` before mapping the
window.