### PR TITLE
wm: fix killing of last client on desktop

### DIFF
--- a/src/wm.c
+++ b/src/wm.c
@@ -494,10 +494,11 @@ static int tmbr_desktop_remove_client(tmbr_desktop_t *desktop, tmbr_client_t *cl
 {
 	if (desktop->focus == client) {
 		int setfocus = (desktop->screen == state.screen && desktop->screen->focus == desktop);
-		tmbr_tree_t *sibling = NULL;
+		tmbr_tree_t *sibling;
 
-		if (tmbr_tree_find_sibling(&sibling, client->tree, TMBR_SELECT_NEAREST) < 0 ||
-		    tmbr_desktop_focus(desktop, sibling ? sibling->client : NULL, setfocus) < 0)
+		if (tmbr_tree_find_sibling(&sibling, client->tree, TMBR_SELECT_NEAREST) < 0)
+			sibling = NULL;
+		if (tmbr_desktop_focus(desktop, sibling ? sibling->client : NULL, setfocus) < 0)
 			return -1;
 	}
 


### PR DESCRIPTION
When killing the last remaining client on the current desktop, then
there will be no sibling remaining to which we can adjust the focus to.
Thus, a failing call to `tmbr_tree_find_sibling` is not an error, but
perfectly fine as we should just set the desktop's focus to `NULL` in
that case. Still, since commit 146a952 (wm: check return value of
`tmbr_desktop_focus`, 2019-07-21) we're raising an error if the function
returned an error.

Fix this by treating an error of `tmbr_tree_find_sibling` as valid.