### PR TITLE
wm: unset fullscreen on focus chaneg

### DIFF
--- a/src/wm.c
+++ b/src/wm.c
@@ -438,9 +438,9 @@ static int tmbr_desktop_focus(tmbr_desktop_t *desktop, tmbr_client_t *client, in
 		return -1;
 	if (desktop->focus == client)
 		return 0;
+	if (desktop->fullscreen && tmbr_client_set_fullscreen(desktop->focus, 0) < 0)
+		return -1;
 
-	if (desktop->fullscreen)
-		tmbr_client_set_fullscreen(desktop->focus, 0);
 	desktop->fullscreen = 0;
 	desktop->focus = client;
 

--- a/src/wm.c
+++ b/src/wm.c
@@ -441,6 +441,7 @@ static int tmbr_desktop_focus(tmbr_desktop_t *desktop, tmbr_client_t *client, in
 
 	if (desktop->fullscreen)
 		tmbr_client_set_fullscreen(desktop->focus, 0);
+	desktop->fullscreen = 0;
 	desktop->focus = client;
 
 	return tmbr_desktop_layout(desktop);


### PR DESCRIPTION
This reverts commit c73fdb34145ba6603aa6cdcd54e4cdb1d59e770c. The commit
causes timber to not unset fullscreen mode when focussing another
client as we weren't calling `tmbr_desktop_set_fullscreen`, but
`tmbr_client_set_fullscreen`.
