### PR TITLE
wm: events: always reset event mask before xcb_flush(1)

### DIFF
--- a/src/wm.c
+++ b/src/wm.c
@@ -866,7 +866,6 @@ static void tmbr_handle_events(void)
 			tmbr_handle_event(ev);
 		free(ev);
 	}
-	state.ignored_events = 0;
 }
 
 static int tmbr_cmd_client_kill(TMBR_UNUSED const tmbr_command_args_t *args)
@@ -1242,9 +1241,6 @@ int tmbr_wm(void)
 		if (poll(fds, 2, -1) < 0)
 			die("timber: unable to poll for events");
 
-		if (fds[0].revents & POLLIN)
-			tmbr_handle_events();
-
 		if (fds[1].revents & POLLIN) {
 			int cfd = accept(fds[1].fd, NULL, NULL);
 			if (cfd < 0)
@@ -1252,6 +1248,11 @@ int tmbr_wm(void)
 			tmbr_handle_command(cfd);
 			close(cfd);
 		}
+
+		if (fds[0].revents & POLLIN)
+			tmbr_handle_events();
+
+		state.ignored_events = 0;
 	}
 
 	return 0;


### PR DESCRIPTION
When an event mask is currently active, then all events queued up that
match the mask will be ignored. To not indefinitely ignore such events,
the mask is being reset when no events are currently queued anymore.
This fails to account for event masks set up by commands, though. As
commands are processed after events, the event mask will not get reset.
Thus, the event mask will remain until the next batch of commands has
been processed.

Fix the issue by reordering command and event handling. Now, we will
always handle commands first, so that any events that shall be ignored
as a result of a command will be queued up. Afterwards, we will handle
these events and potentially ignore any that match the event mask.
Furthermore, we now always reset the event mask independent of whether
any events were processed or not.