### PR TITLE
wm: fix focus change when unmapping unmanaged windows

### DIFF
--- a/src/wm.c
+++ b/src/wm.c
@@ -795,9 +795,8 @@ static void tmbr_handle_map_request(xcb_map_request_event_t *ev)
 static void tmbr_handle_unmap_notify(xcb_unmap_notify_event_t *ev)
 {
 	tmbr_client_t *client;
-	if (tmbr_client_find_by_window(&client, ev->window) < 0)
-		return;
-	if (tmbr_client_set_wm_state(client, TMBR_WM_STATE_WITHDRAWN) < 0)
+	if (tmbr_client_find_by_window(&client, ev->window) == 0 &&
+	    tmbr_client_set_wm_state(client, TMBR_WM_STATE_WITHDRAWN) < 0)
 		die("Unable to set WM state to 'withdrawn'");
 	xcb_aux_sync(state.conn);
 	state.ignored_events = XCB_ENTER_NOTIFY;


### PR DESCRIPTION
When windows get unmapped, they may uncover underlying windows that they
have previously been obstructing. In case the unmapped window is an
unmanaged window, we thus need to ignore EnterNotify events in order to
not act like the mouse just moved into the now-uncovered window and to
retain the current focus. While the code already wants to do this, we do
in fact exit early if we notice that the unmapped window is not managed
by us. As a result, we fail to correctly set up the ignored events to
start ignoring EnterNotify.

Fix the issue by always executing the event synchronization and setup of
the ignored event.