### PR TITLE
Control packets

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,5 @@
+root = true
+
 [*]
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/src/common.c
+++ b/src/common.c
@@ -205,22 +205,21 @@ ssize_t tmbr_ctrl_read(int fd, char *buf, size_t bufsize)
 	return (ssize_t) n;
 }
 
-ssize_t tmbr_ctrl_write(int fd, const char *buf, size_t bufsize)
+static int write_bytes(int fd, const char *buf, size_t bufsize)
 {
-	size_t n = 0;
-	while (n < bufsize) {
-		ssize_t bytes = write(fd, buf + n, bufsize - n);
-		if (bytes <= 0) {
-			if (bytes < 0 && (errno == EAGAIN || errno == EINTR))
-				continue;
+	size_t total = 0;
+	while (total < bufsize) {
+		ssize_t bytes = write(fd, buf + total, bufsize - total);
+		if (bytes < 0 && (errno == EAGAIN || errno == EINTR))
+			continue;
+		if (bytes <= 0)
 			return -1;
-		}
-		n += (size_t) bytes;
+		total += (size_t) bytes;
 	}
-	return (ssize_t) n;
+	return 0;
 }
 
-ssize_t tmbr_ctrl_writef(int fd, const char *fmt, ...)
+int tmbr_ctrl_writef(int fd, const char *fmt, ...)
 {
 	char buf[TMBR_CTRL_BUFSIZE];
 	va_list ap;
@@ -233,5 +232,5 @@ ssize_t tmbr_ctrl_writef(int fd, const char *fmt, ...)
 	if (n < 0)
 		return -1;
 
-	return tmbr_ctrl_write(fd, buf, (size_t)(n + 1));
+	return write_bytes(fd, buf, (size_t)(n + 1));
 }

--- a/src/common.h
+++ b/src/common.h
@@ -87,5 +87,4 @@ int tmbr_command_parse(tmbr_command_t *cmd, tmbr_command_args_t *args, int argc,
 
 int tmbr_ctrl_connect(const char **out_path, char create);
 ssize_t tmbr_ctrl_read(int fd, char *buf, size_t bufsize);
-ssize_t tmbr_ctrl_write(int fd, const char *buf, size_t bufsize);
-ssize_t __attribute__((format(printf, 2, 3))) tmbr_ctrl_writef(int fd, const char *fmt, ...);
+int __attribute__((format(printf, 2, 3))) tmbr_ctrl_writef(int fd, const char *fmt, ...);

--- a/src/common.h
+++ b/src/common.h
@@ -27,7 +27,8 @@
 	if (i == ARRAY_SIZE(array)) \
 		i = -1;
 
-#define TMBR_CTRL_BUFSIZE 1024
+#define TMBR_PKT_MESSAGELEN 1024
+#define TMBR_PKT_PREFIXLEN 5
 
 #define TMBR_ARG_SEL (1 << 1)
 #define TMBR_ARG_DIR (1 << 2)
@@ -74,6 +75,17 @@ typedef struct {
 	int args;
 } tmbr_commands_t;
 
+typedef enum {
+	TMBR_PKT_COMMAND,
+	TMBR_PKT_ERROR,
+	TMBR_PKT_LAST
+} tmbr_pkt_type_t;
+
+typedef struct {
+	tmbr_pkt_type_t type;
+	char message[TMBR_PKT_MESSAGELEN];
+} tmbr_pkt_t;
+
 extern const tmbr_commands_t commands[];
 extern const char *directions[];
 extern const char *selections[];
@@ -86,5 +98,5 @@ void *tmbr_alloc(size_t bytes, const char *msg);
 int tmbr_command_parse(tmbr_command_t *cmd, tmbr_command_args_t *args, int argc, const char *argv[]);
 
 int tmbr_ctrl_connect(const char **out_path, char create);
-ssize_t tmbr_ctrl_read(int fd, char *buf, size_t bufsize);
-int __attribute__((format(printf, 2, 3))) tmbr_ctrl_writef(int fd, const char *fmt, ...);
+int tmbr_ctrl_read(int fd, tmbr_pkt_t *out);
+int __attribute__((format(printf, 3, 4))) tmbr_ctrl_write(int fd, tmbr_pkt_type_t type, const char *fmt, ...);

--- a/src/wm.c
+++ b/src/wm.c
@@ -1057,16 +1057,16 @@ static int tmbr_cmd_tree_rotate(TMBR_UNUSED const tmbr_command_args_t *args)
 
 static void tmbr_handle_command(int fd)
 {
-	char buf[TMBR_CTRL_BUFSIZE];
 	tmbr_command_args_t args;
 	tmbr_command_t command;
+	tmbr_pkt_t pkt;
 	const char *argv[10];
 	int error, argc;
 
-	if (tmbr_ctrl_read(fd, buf, sizeof(buf)) < 0)
+	if (tmbr_ctrl_read(fd, &pkt) < 0 || pkt.type != TMBR_PKT_COMMAND)
 		return;
 
-	if ((argv[0] = strtok(buf, " ")) == NULL)
+	if ((argv[0] = strtok(pkt.message, " ")) == NULL)
 		return;
 	for (argc = 1; argc < (int) ARRAY_SIZE(argv); argc++)
 		if ((argv[argc] = strtok(NULL, " ")) == NULL)
@@ -1093,7 +1093,7 @@ static void tmbr_handle_command(int fd)
 		case TMBR_COMMAND_TREE_ROTATE: error = tmbr_cmd_tree_rotate(&args); break;
 	}
 
-	tmbr_ctrl_writef(fd, "%d", error);
+	tmbr_ctrl_write(fd, TMBR_PKT_ERROR, "%d", error);
 }
 
 static void tmbr_cleanup(TMBR_UNUSED int signal)


### PR DESCRIPTION
Refactor the wire-protocol to use a prefix encoding for both packet type as well as packet length. This enables us to send more information over the wire in the future.